### PR TITLE
Implement layout for the index page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,7 +16,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <div className="h-screen grid place-items-center">{children}</div>
+      </body>
     </html>
   );
 }

--- a/src/components/routeRelated/index/SolidText/SolidText.tsx
+++ b/src/components/routeRelated/index/SolidText/SolidText.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { SolidLetter } from "./SolidLetter";
 import { Explanation } from "./Explanation";
 
@@ -29,9 +29,17 @@ export const SolidText = () => {
         <SolidLetter setLetterOnHover={handleSetLetterOnHover} letter="D" />
       </section>
 
-      {letterOnHover && (
-        <Explanation message={solidAbbreviation[letterOnHover]} />
-      )}
+      {/* hack to make the explanation appear/disappear without making the layout jump  */}
+      <div
+        className="min-h-[100px] transition-opacity duration-700"
+        style={{ opacity: letterOnHover ? 1 : 0 }}
+      >
+        {letterOnHover ? (
+          <Explanation message={solidAbbreviation[letterOnHover]} />
+        ) : (
+          <div></div>
+        )}
+      </div>
     </>
   );
 };


### PR DESCRIPTION
Just a simple X and Y centering of the elements

Also, change how the `Explanation` component renders on the page:

- Reserve a space of 100 pixels for it to ensure the layout wont be jumping.
- Add opacity and duration to it so that it appears smoother on the page.