### PR TITLE
Rearrange layout holding divs

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,9 +18,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <div className="h-screen flex flex-col">
+        <div className=" flex flex-col">
           <Navbar />
-          <div className="flex-grow grid place-items-center">{children}</div>
+          {children}
         </div>
       </body>
     </html>

--- a/src/components/routeRelated/index/SolidText/SolidText.tsx
+++ b/src/components/routeRelated/index/SolidText/SolidText.tsx
@@ -20,7 +20,7 @@ export const SolidText = () => {
   };
 
   return (
-    <>
+    <div>
       <section>
         <SolidLetter setLetterOnHover={handleSetLetterOnHover} letter="S" />
         <SolidLetter setLetterOnHover={handleSetLetterOnHover} letter="O" />
@@ -40,6 +40,6 @@ export const SolidText = () => {
           <div></div>
         )}
       </div>
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
Rearranged the divs that make up the layout of the page. This is to make the page more responsive and to make it easier to add new components in the future. Also, the root page will have a faq that should have its own "layout".